### PR TITLE
Add the possibility of not specifying privkey

### DIFF
--- a/src/commands/signCommand.ts
+++ b/src/commands/signCommand.ts
@@ -10,11 +10,6 @@ export const signOptions = {
     choices: ["sr25519", "ethereum"],
     demandOption: true,
   },
-  "private-key": {
-    alias: "mnemonic",
-    describe: "private key or mnemonic for the signature",
-    type: "string" as "string",
-  },
   derivePath: {
     describe: "derivation path for bip-44 (optional)",
     type: "string" as "string",
@@ -34,9 +29,19 @@ export const signCommand = {
         type: "string" as "string",
         demandOption: true,
       },
+      "private-key": {
+        alias: "mnemonic",
+        describe: "private key or mnemonic for the signature",
+        type: "string" as "string",
+        demandOption: true,
+      },
     });
   },
   handler: async (argv: SignArgs) => {
+    if (!argv["private-key"]) {
+      console.log(`Missing private key`);
+      return;
+    }
     if (!argv["type"]) {
       console.log(`Missing type`);
       return;
@@ -47,19 +52,15 @@ export const signCommand = {
 
 export const signPromptCommand = {
   command: "signPrompt",
-  describe: "sign byteCode with a private key - using prompt",
+  describe: "sign byteCode with a private key - using prompt for message and private key",
   builder: (yargs: Argv) => {
     return yargs.options(signOptions);
   },
   handler: async (argv: SignPromptArgs) => {
-    if (!argv["private-key"]) {
-      console.log(`Missing private key`);
-      return;
-    }
     if (!argv["type"]) {
       console.log(`Missing type`);
       return;
     }
-    await sign(isNetworkType(argv.type), argv["private-key"], true, argv.derivePath);
+    await sign(isNetworkType(argv.type), undefined, true, argv.derivePath);
   },
 };

--- a/src/commands/signCommand.ts
+++ b/src/commands/signCommand.ts
@@ -14,7 +14,6 @@ export const signOptions = {
     alias: "mnemonic",
     describe: "private key or mnemonic for the signature",
     type: "string" as "string",
-    demandOption: true,
   },
   derivePath: {
     describe: "derivation path for bip-44 (optional)",
@@ -38,10 +37,6 @@ export const signCommand = {
     });
   },
   handler: async (argv: SignArgs) => {
-    if (!argv["private-key"]) {
-      console.log(`Missing private key`);
-      return;
-    }
     if (!argv["type"]) {
       console.log(`Missing type`);
       return;

--- a/src/methods/createAndSendTx.ts
+++ b/src/methods/createAndSendTx.ts
@@ -5,7 +5,7 @@ import { ISubmittableResult, SignerPayloadJSON } from "@polkadot/types/types";
 import prompts from "prompts";
 import Keyring from "@polkadot/keyring";
 import { blake2AsHex } from "@polkadot/util-crypto";
-import chalk from "chalk"
+import chalk from "chalk";
 
 import { moonbeamChains } from "./utils";
 import { SignerResult, SubmittableExtrinsic } from "@polkadot/api/types";
@@ -39,8 +39,14 @@ export async function createAndSendTx(
   }
 
   // explicit display of name, args
-  const { method: { args, method, section } } = txExtrinsic;
-  console.log(`Transaction created:\n${chalk.red(`${section}.${method}`)}(${chalk.green(`${args.map((a) => a.toString().slice(0, 200)).join(chalk.white(', '))}`)})\n`);
+  const {
+    method: { args, method, section },
+  } = txExtrinsic;
+  console.log(
+    `Transaction created:\n${chalk.red(`${section}.${method}`)}(${chalk.green(
+      `${args.map((a) => a.toString().slice(0, 200)).join(chalk.white(", "))}`
+    )})\n`
+  );
 
   const signer = {
     signPayload: (payload: SignerPayloadJSON) => {
@@ -74,16 +80,16 @@ export async function createAndSendTx(
 
       if (status.isInBlock) {
         console.log("Included at block hash", status.asInBlock.toHex());
-        console.log('Events: ');
+        console.log("Events: ");
         events.forEach(({ event: { data, method, section } }) => {
           const [error] = data as any[];
           if (error?.isModule) {
             const { docs, name, section } = api.registry.findMetaError(error.asModule);
-            console.log('\t', `${chalk.red(`${section}.${name}`)}`, `${docs}`);
-          } else if (section=="system" && method == "ExtrinsicSuccess") {
-            console.log('\t', chalk.green(`${section}.${method}`), data.toString());
+            console.log("\t", `${chalk.red(`${section}.${name}`)}`, `${docs}`);
+          } else if (section == "system" && method == "ExtrinsicSuccess") {
+            console.log("\t", chalk.green(`${section}.${method}`), data.toString());
           } else {
-            console.log('\t', `${section}.${method}`, data.toString());
+            console.log("\t", `${section}.${method}`, data.toString());
           }
         });
         resolve();

--- a/src/methods/sign.ts
+++ b/src/methods/sign.ts
@@ -9,7 +9,7 @@ import { NetworkType } from "./types";
 // TODO display payload content
 export async function sign(
   type: NetworkType,
-  privKeyOrMnemonic: string,
+  privateKeyOrMnemonic: string | undefined,
   prompt: boolean,
   derivePath: string,
   message?: string
@@ -21,6 +21,18 @@ export async function sign(
   // Instantiate keyring
   let keyringType: KeypairType = type === "ethereum" ? "ethereum" : "sr25519";
   let keyring: Keyring = new Keyring({ type: keyringType });
+
+  // If no provided priv key, fetch it from prompt
+  const privKeyOrMnemonic =
+    privateKeyOrMnemonic ||
+    (
+      await prompts({
+        type: "text",
+        name: "privKeyOrMnemonic",
+        message: "Please enter private key or mnemonic",
+        validate: (value) => true, // TODO: add validation
+      })
+    ).privKeyOrMnemonic;
 
   // Support both private key and mnemonic
   const signer: KeyringPair =


### PR DESCRIPTION
And enter it in prompt instead

In order to enter message and private-key inputs as prompt, one has to use `signPrompt`

ex: `npm run cli signPrompt -- --type "ethereum"`

closes #24 