### PR TITLE
fix: unable to call no-param extrinsic

### DIFF
--- a/src/methods/createAndSendTx.ts
+++ b/src/methods/createAndSendTx.ts
@@ -31,10 +31,19 @@ export async function createAndSendTx(
     });
   }
   let txExtrinsic: SubmittableExtrinsic<"promise", ISubmittableResult>;
+  // For empty param, submit the tx without arguments
   if (sudo) {
-    txExtrinsic = await api.tx.sudo.sudo(api.tx[section][method](...splitParams));
+    if ((params as string).length === 0) {
+      txExtrinsic = await api.tx.sudo.sudo(api.tx[section][method]());
+    } else {
+      txExtrinsic = await api.tx.sudo.sudo(api.tx[section][method](...splitParams));
+    }
   } else {
-    txExtrinsic = await api.tx[section][method](...splitParams);
+    if ((params as string).length === 0) {
+      txExtrinsic = await api.tx[section][method]();
+    } else {
+      txExtrinsic = await api.tx[section][method](...splitParams);
+    }
   }
   const signer = {
     signPayload: (payload: SignerPayloadJSON) => {


### PR DESCRIPTION
Hi guys, 

I'm a collator on Moonbeam network (also an orbiter on MOVR) and have some needs to sign no-param extrinsics like `moonbeamOrbiters.orbiterRegister()` offline. But I found this offline sign always convert an empty param list to a one-item array so I made some modifications to make it work. 

Before the fix, I will get:

```
./moonbeam-signer-macos createAndSendTx "moonbeam" wss://wss.api.moonbeam.network "<our_orbiter_address>" "moonbeamOrbiters.orbiterRegister" ""

Error: Extrinsic moonbeamOrbiters.orbiterRegister expects 0 arguments, got 1.
    at assert (/snapshot/dist/index.js)
    at extrinsicFn (/snapshot/dist/index.js)
    at Object.decorated [as orbiterRegister] (/snapshot/dist/index.js)
    at createAndSendTx (/snapshot/dist/index.js)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
    at async Object.handler (/snapshot/dist/index.js)
```

After fix, it could work.

Feel free to contact if there's any issue. Many Thanks!

Adam